### PR TITLE
add Commas and URLfix features

### DIFF
--- a/src/PersianTools.php
+++ b/src/PersianTools.php
@@ -4,9 +4,13 @@ namespace PersianTools;
 
 use PersianTools\Traits\RemoveOrdinalSuffix;
 use PersianTools\Traits\WordsToNumber;
+use PersianTools\Traits\URLfix;
+use PersianTools\Traits\Commas;
 
 class PersianTools
 {
     use RemoveOrdinalSuffix,
-        WordsToNumber;
+        WordsToNumber,
+        URLfix,
+        Commas;
 }

--- a/src/Traits/Commas.php
+++ b/src/Traits/Commas.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PersianTools\Traits;
+
+trait Commas
+{
+    /**
+     * Add commas to numbers
+     *
+     * @param  $number
+     * @return string
+     */
+    static public function addCommas($number)
+    {
+        // todo : parameter must be numeric
+        $floatNumber = floatval(str_replace(',', '', $number));
+        return !empty($number) ? number_format($floatNumber, strlen(substr(strrchr($floatNumber, "."), 1))) : '';
+    }
+
+     /**
+     * Remove commas from numbers
+    *
+    * @param  $number
+    * @return string
+    */
+    static public function removeCommas($number)
+    {
+        // todo : parameter must be numeric
+        return !empty($number) ? str_replace(',', '', $number) : '';
+    }
+}

--- a/src/Traits/URLfix.php
+++ b/src/Traits/URLfix.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PersianTools\Traits;
+
+trait URLfix
+{
+    /**
+     * fix url
+     *
+     * @param  string  $url
+     * @return string
+     */
+    static public function URLfix(string $url)
+    {
+        return urldecode($url);
+    }
+}

--- a/tests/CommasTest.php
+++ b/tests/CommasTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PersianTools\Tests;
+
+use PersianTools\PersianTools;
+use PHPUnit\Framework\TestCase;
+
+class CommasTest extends TestCase
+{
+    public function testAddCommas()
+    {
+        $this->assertEquals('30,000,000', PersianTools::addCommas(30000000));
+        $this->assertEquals('30,000,000', PersianTools::addCommas('30,000,000'));
+        $this->assertEquals('30,000,000.02', PersianTools::addCommas(30000000.02));
+        $this->assertEquals('30,000,000.002', PersianTools::addCommas(30000000.002));
+        $this->assertEquals('30,000,000.002', PersianTools::addCommas('30,000,000.002'));
+        $this->assertEquals('', PersianTools::addCommas(''));
+    }
+
+    public function testRemoveCommas()
+    {
+        $this->assertEquals(30000000, PersianTools::removeCommas('30,000,000'));
+        $this->assertEquals(30000000.02, PersianTools::removeCommas('30,000,000.02'));
+        $this->assertEquals(300, PersianTools::removeCommas('300'));
+        $this->assertEquals('', PersianTools::removeCommas(''));
+    }
+
+}

--- a/tests/URLfixTest.php
+++ b/tests/URLfixTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PersianTools\Tests;
+
+use PersianTools\PersianTools;
+use PHPUnit\Framework\TestCase;
+
+class URLfixTest extends TestCase
+{
+    public function testURLfix()
+    {
+        $this->assertEquals('https://fa.wikipedia.org/wiki/مدیاویکی:Gadget-Extra-Editbuttons-botworks.js', PersianTools::URLfix('https://fa.wikipedia.org/wiki/%D9%85%D8%AF%DB%8C%D8%A7%D9%88%DB%8C%DA%A9%DB%8C:Gadget-Extra-Editbuttons-botworks.js'));
+        $this->assertEquals('https://en.wikipedia.org/wiki/Persian_alphabet', PersianTools::URLfix('https://en.wikipedia.org/wiki/Persian_alphabet'));
+        $this->assertEquals('', PersianTools::URLfix(''));
+    }
+}


### PR DESCRIPTION
<p dir='rtl'>
زبان php بعضی از ابزار ها رو داره . مثلا برای urlfix خودش urldecode داره اما اگر من درست متوجه ابزار نشدم لطفا راهنمایی کنید<br>
هدف از اضافه کردن ، هماهنگی با syntax ابزار مرجع هست که اگر دوستان بین زبان ها جابجا شدن راحت تر بتونن استفاده کنن
</p>